### PR TITLE
Change repo to aliyun for speeding up building image.

### DIFF
--- a/scripts/Docker/build.sh
+++ b/scripts/Docker/build.sh
@@ -46,6 +46,8 @@ MAINTAINER BuddyZhang1 <buddy.zhang@aliyun.com>
 
 # Base Build ENV tools
 RUN /bin/bash -c '\
+sed -i s/archive.ubuntu.com/mirrors.aliyun.com/g /etc/apt/sources.list && \
+sed -i s/security.ubuntu.com/mirrors.aliyun.com/g /etc/apt/sources.list && \
 apt-get update && \
 apt-get install -y qemu bc gcc make gdb git figlet && \
 apt-get install -y libncurses5-dev iasl sudo && \


### PR DESCRIPTION
Signed-off-by: FanJun Kong <bh1scw@gmail.com>

Using default ubuntu repo will lead an error as follows:

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/universe/f/figlet/figlet_2.2.5-3_amd64.deb  Connection failed [IP: 91.189.91.39 80]

Changing to aliyun will fix this error and this will have better speed of downloading packages.